### PR TITLE
Lhuang/topper 2.0 final

### DIFF
--- a/components/byline.mjs
+++ b/components/byline.mjs
@@ -37,17 +37,21 @@ return (
                   />
                 )
               })}
-              &nbsp;|&nbsp;
               </>
             }
             {!has_authors && <span>Published </span>}
-              <time
-                className="topper-dateline"
-                dateTime={ISO_PUBDATE}
-                itemProp="datePublished"
-              >
-                {pubdateString}
-              </time>
+              { !moddateString && 
+                <>
+                  &nbsp;|&nbsp;
+                  <time
+                    className="topper-dateline"
+                    dateTime={ISO_PUBDATE}
+                    itemProp="datePublished"
+                  >
+                    {pubdateString}
+                  </time>
+                </>
+              }
               {moddateString && (
                 <Fragment>
                   &nbsp;|&nbsp;
@@ -61,8 +65,10 @@ return (
                 </Fragment>
               )}
             </div>
-            <div id="sharebutton-wrapper">
-              <ShareButtons meta={meta} />
+            <div className="articleHeader--shareTools">
+              <div className="share-list" id="sharebutton-wrapper">
+                <ShareButtons meta={meta} />
+              </div>
             </div>
         </div>
     </>

--- a/components/topper2.mjs
+++ b/components/topper2.mjs
@@ -156,19 +156,26 @@ const Topper2 = ({ settings, wcmData, lazyloader }) => {
   const calculatefullScreenOffsets = () => {
     var r = document.querySelector(':root');
 
-    var verticalOffset = Number(HeaderDek_Vertical_Offset.slice(0, -2));
-    var horizontalOffset = Number(HeaderDek_Horizontal_Offset.slice(0, -2));
-
-    // in case of invalid inputs, reset offsets to 0
-    if (isNaN(verticalOffset)) verticalOffset = 0;
-    if (isNaN(horizontalOffset)) verticalOffset = 0;
-
-    // invert direction of offset for bottom and right positions
-    if (HeaderDek_Vertical_Position === "bottom") verticalOffset *= -1;
-    if (HeaderDek_Horizontal_Position === "right") horizontalOffset *= -1;
+    let verticalOffset = convertStringToNumber(HeaderDek_Vertical_Offset, (HeaderDek_Vertical_Position === "bottom"));
+    let horizontalOffset = convertStringToNumber(HeaderDek_Horizontal_Offset, (HeaderDek_Horizontal_Position === "right"));
 
     r.style.setProperty('--headerDek-vertical-offset', verticalOffset + "px" ); 
     r.style.setProperty('--headerDek-horizontal-offset', horizontalOffset + "px"); 
+  }
+
+  const convertStringToNumber = (maybeStr, isFlipped) => {
+    var num = 0;
+    if (typeof(maybeStr) === "string") {
+      // remove all non-number characters and "-" from string
+      num = Number(maybeStr.replace(/(?!^)-|[^0-9-]/g,''))
+    } else {
+      num = maybeStr
+    }
+
+    if (isNaN(num)) num = 0;
+    if (isFlipped) num *= -1;
+
+    return num;
   }
 
   const calculateFullScreenImageRatio = () => {

--- a/example/src/components/layout.js
+++ b/example/src/components/layout.js
@@ -160,7 +160,7 @@ const Layout = ({
           type="image/x-icon"
         />
         <link rel="canonical" href={ CANONICAL_URL } />
-        <link rel="stylesheet" href={`https://sfc-project-files.s3.amazonaws.com/brand-styles/${styleSheetID}.css`} />
+        <link rel="stylesheet" href={`https://files.sfchronicle.com/brand-styles/${styleSheetID}.css`} />
 
         {(isApp || EMBEDDED) ? (
           <meta name="robots" content="noindex, nofollow" />

--- a/settings.js
+++ b/settings.js
@@ -28,8 +28,11 @@ let getSettings = function(){
 	let fullAuthors = []
 	try {
     try {
-    	// Check for classic story_settings sheet
-    	[storySettings] = require("../../src/data/story_settings.sheet.json")
+    	// TODO: can we remove this? 
+			// [storySettings] = require("../../src/data/story_settings.sheet.json")
+			
+			// Check for classic story_settings sheet
+			[storySettings] = require("./example/src/data/story_settings.sheet.json")
 			// If we got story_settings, try structuring the AUTHORS object
 			let authorNames = []
 			let authorLinks = []

--- a/styles/modules/topper2.module.less
+++ b/styles/modules/topper2.module.less
@@ -145,6 +145,10 @@
 .whiteTextBlackBg {
   color: @white;
   background-color: rgba(0, 0, 0, 0.54);
+  @media @mobile {
+    color: @black;
+    background-color: transparent;
+  }
 }
 
 .blackTextWhiteBg {


### PR DESCRIPTION
note (to self): 

The `CaptionCredit` component is added twice to the full screen implementation bc the header-deck needs to bind to the bottom of the full screen image. However, if the `WCMImage` component contains the caption-credit, the header-deck component will be shifted to the bottom of the caption instead of to the bottom of the image:
 
![Screen Shot 2023-01-19 at 11 03 13 AM](https://user-images.githubusercontent.com/117930473/213492162-ba44c63e-66d8-4ed7-888e-4e4523e47b31.png)

Furthermore, to maintain separation of responsibilities, the core `WCMImage` component should only include an image to support all use cases, and a wrapper component can be created to represent the WCM image + caption grouping (as well as inserting the lazyloader, etc).
