### PR TITLE
component tracking and location prop for share buttons

### DIFF
--- a/components/sharebuttons.mjs
+++ b/components/sharebuttons.mjs
@@ -38,8 +38,8 @@ const ShareButtons = ({ meta, urlAdd, location = "Byline" }) => {
           <a
             href={`https://www.facebook.com/sharer/sharer.php?u=${meta.MAIN_DOMAIN}%2F${subfolder}${meta.PROJECT.SLUG}%2F${urlAdd}`}
             className={shareStyles.link}
-            onClick={() => {
-              facebookClick();
+            onClick={(e) => {
+              facebookClick(e);
               trackEvent("Click", "Button", "Share", `Facebook|${location}`);
             }}
           >

--- a/components/sharebuttons.mjs
+++ b/components/sharebuttons.mjs
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
 import * as shareStyles from "../styles/modules/share.module.less";
 import { appCheck } from "../appcheck.js";
+import { trackEvent } from "../components/helpers/utilfunctions.mjs";
 
-const ShareButtons = ({ meta, urlAdd }) => {
+const ShareButtons = ({ meta, urlAdd, location = "Byline" }) => {
   // We need to run appCheck in useEffect because we need to wait for the DOM to be ready
   let [hideSocial, setHideSocial] = useState(false);
   useEffect(() => {
@@ -37,7 +38,10 @@ const ShareButtons = ({ meta, urlAdd }) => {
           <a
             href={`https://www.facebook.com/sharer/sharer.php?u=${meta.MAIN_DOMAIN}%2F${subfolder}${meta.PROJECT.SLUG}%2F${urlAdd}`}
             className={shareStyles.link}
-            onClick={facebookClick}
+            onClick={() => {
+              facebookClick();
+              trackEvent("Click", "Button", "Share", `Facebook|${location}`);
+            }}
           >
             <svg
               className={shareStyles.svg}
@@ -59,6 +63,9 @@ const ShareButtons = ({ meta, urlAdd }) => {
           <a
             href={`https://x.com/intent/post?url=${meta.MAIN_DOMAIN}%2F${subfolder}${meta.PROJECT.SLUG}%2F${urlAdd}&text=${meta.PROJECT.TWITTER_TEXT}`}
             className={shareStyles.link}
+            onClick={() => {
+              trackEvent("Click", "Button", "Share", `X|${location}`);
+            }}
           >
             {/* <svg
               className={shareStyles.svg}
@@ -95,6 +102,9 @@ const ShareButtons = ({ meta, urlAdd }) => {
           <a
             href={`https://bsky.app/intent/compose?text=${meta.PROJECT.TWITTER_TEXT}&url=${meta.MAIN_DOMAIN}%2F${subfolder}${meta.PROJECT.SLUG}%${urlAdd}`}
             className={shareStyles.link}
+            onClick={() => {
+              trackEvent("Click", "Button", "Share", `Bluesky|${location}`);
+            }}
           >
             <svg
               className={shareStyles.svg}
@@ -107,7 +117,9 @@ const ShareButtons = ({ meta, urlAdd }) => {
             >
               <path
                 data-name="Bluesky Logo"
-                fill="currentColor" d="M111.8 62.2C170.2 105.9 233 194.7 256 242.4c23-47.6 85.8-136.4 144.2-180.2c42.1-31.6 110.3-56 110.3 21.8c0 15.5-8.9 130.5-14.1 149.2C478.2 298 412 314.6 353.1 304.5c102.9 17.5 129.1 75.5 72.5 133.5c-107.4 110.2-154.3-27.6-166.3-62.9l0 0c-1.7-4.9-2.6-7.8-3.3-7.8s-1.6 3-3.3 7.8l0 0c-12 35.3-59 173.1-166.3 62.9c-56.5-58-30.4-116 72.5-133.5C100 314.6 33.8 298 15.7 233.1C10.4 214.4 1.5 99.4 1.5 83.9c0-77.8 68.2-53.4 110.3-21.8z"/>
+                fill="currentColor"
+                d="M111.8 62.2C170.2 105.9 233 194.7 256 242.4c23-47.6 85.8-136.4 144.2-180.2c42.1-31.6 110.3-56 110.3 21.8c0 15.5-8.9 130.5-14.1 149.2C478.2 298 412 314.6 353.1 304.5c102.9 17.5 129.1 75.5 72.5 133.5c-107.4 110.2-154.3-27.6-166.3-62.9l0 0c-1.7-4.9-2.6-7.8-3.3-7.8s-1.6 3-3.3 7.8l0 0c-12 35.3-59 173.1-166.3 62.9c-56.5-58-30.4-116 72.5-133.5C100 314.6 33.8 298 15.7 233.1C10.4 214.4 1.5 99.4 1.5 83.9c0-77.8 68.2-53.4 110.3-21.8z"
+              />
             </svg>
           </a>
         </>
@@ -116,6 +128,9 @@ const ShareButtons = ({ meta, urlAdd }) => {
       <a
         href={`mailto:?subject=${meta.PROJECT.TITLE}&body=${meta.PROJECT.DESCRIPTION}%0A%0A${meta.MAIN_DOMAIN}%2F${subfolder}${meta.PROJECT.SLUG}%2F${urlAdd}`}
         className={shareStyles.link}
+        onClick={() => {
+          trackEvent("Click", "Button", "Share", `Email|${location}`);
+        }}
       >
         <svg
           className={shareStyles.svg}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sfc-utils",
-  "version": "1.4.181",
+  "version": "1.4.182",
   "author": "ewagstaff <evanjwagstaff@gmail.com>",
   "dependencies": {
     "archieml": "^0.4.2",


### PR DESCRIPTION
- Add component tracking calls to each of the four share buttons by using click events on each anchor tag
- Add a new optional `location` prop with a default of "Byline," to be used in each tracking call; this can be used if share buttons are being used in a custom component that isn't the byline.